### PR TITLE
修正多线程处理逻辑错误，修正含有非 ASCii 字符文件名导致的问题，调整 CMake 配置以通过 MSVC 正确编译

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 2.9)
 project(qmc-decoder)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -std=c++17")
+
+# Judge the compiler to use different parameters
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pipe -std=c++17")
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 include_directories(${Boost_INCLUDE_DIRS})
 aux_source_directory(src SRC)

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
   const auto n_thread = thread::hardware_concurrency();
   vector<thread> td_group;
 
-  for (size_t i = 0; i < n_thread - 1; ++i) {
+  for (size_t i = 0; i < n_thread; ++i) {
     td_group.emplace_back(
         [&qmc_paths, &n_thread](int index) {
           for (size_t j = index; j < qmc_paths.size(); j += n_thread) {

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -74,6 +74,9 @@ void sub_process(const string &dir) {
 }
 
 int main(int argc, char **argv) {
+  // Set locale encoding to properly handle files containing non-ASCii characters in the file name
+  setlocale(LC_ALL,".UTF-8");
+  std::locale::global(std::locale(".UTF-8"));
   if (argc > 1) {
     std::cerr
         << "put decoder binary file in your qmc file directory, then run it."
@@ -92,6 +95,7 @@ int main(int argc, char **argv) {
 
   for (fs::recursive_directory_iterator i{fs::path(".")}, end; i != end; ++i) {
     auto file_path = i->path().string();
+    // std::cout<<file_path<<endl;
     if ((fs::status(*i).permissions() & fs::perms::owner_read) !=
             fs::perms::none &&
         fs::is_regular_file(*i) && regex_match(file_path, qmc_regex)) {


### PR DESCRIPTION
- 通过设置 locale 编码以正确处理文件名含有非 ASCii 字符的文件
- 在 CMakeLists.txt 中增加对编译器的判断逻辑，使之向 MSVC 编译器传递正确的参数以指定 C++ 标准通过编译