### PR TITLE
Add GitHub Action CI to build binary distribution realtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,4 @@ jobs:
       with:
         name: linux
         path: ./build/*
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,15 @@ jobs:
       with: 
         submodules: recursive
       
-    - name: Preparation
+    - name: Prepare Environment
       uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.arch }}
-        
+
     - name: Make
-      working-directory: ./build
       run: |
+        mkdir build
+        cd build
         cmake -G "NMake Makefiles" .. -DCMAKE_BUILD_TYPE=Release
         nmake
     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       name: Clone Repository
+      with: 
+        submodules: recursive
       
     - name: Preparation
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
     - name: Preparation
       run: |
         sudo apt-get update -y
-        sudo apt-get upgrade -y
         sudo apt=get install cmake -y
         mkdir build
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Preparation
       run: |
         sudo apt-get update -y
-        sudo apt=get install cmake -y
+        sudo apt-get install cmake -y
         mkdir build
         
     - name: Make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       working-directory: ./build
       run: |
         cmake ..
-        make -j2
+        make
     
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
@@ -90,4 +90,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: macos
-        path: ./build/*
+        path: ./build/decoder

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: Build Binary
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  linux:
+    name: Build on Linux
     runs-on: ubuntu-latest
 
     steps:
@@ -24,15 +24,39 @@ jobs:
         mkdir build
         
     - name: Make
+      working-directory: ./build
       run: |
-        cd build
         cmake ..
         make -j2
-        cd ..
     
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
         name: linux
-        path: ./build/*
-
+        path: ./build/decoder
+  
+  windows:
+    name: Build on Windows
+    runs-on: windows-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+      name: Clone Repository
+      with: 
+        submodules: recursive
+      
+    - name: Preparation
+      run: |
+        mkdir build
+        
+    - name: Make
+      working-directory: ./build
+      run: |
+        cmake -G "NMake Makefiles" .. -DCMAKE_BUILD_TYPE=Release
+        nmake
+    
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows
+        path: ./build/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       with: 
         submodules: recursive
       
-    - name: Prepare Environment
+    - name: Preparation
       uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.arch }}
@@ -64,4 +64,30 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: windows_${{ matrix.arch }}
-        path: ./build/
+        path: ./build/decoder.exe
+
+  macos:
+    name: Build on MacOS
+    runs-on: macos-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+      name: Clone Repository
+      with: 
+        submodules: recursive
+
+    - name: Preparation
+      run: |
+        mkdir build
+
+    - name: Make
+      working-directory: ./build
+      run: |
+        cmake ..
+        make
+  
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: macos
+        path: ./build/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Clone Repository
+      
+    - name: Preparation
+      run: |
+        sudo apt-get update -y
+        sudo apt-get upgrade -y
+        sudo apt=get install cmake -y
+        mkdir build
+        
+    - name: Make
+      run: |
+        cd build
+        cmake ..
+        make -j2
+        cd ..
+    
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux
+        path: ./build/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
   windows:
     name: Build on Windows
     runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: ["x86","x64"]
     
     steps:
     - uses: actions/checkout@v2
@@ -46,8 +49,9 @@ jobs:
         submodules: recursive
       
     - name: Preparation
-      run: |
-        mkdir build
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
         
     - name: Make
       working-directory: ./build
@@ -58,5 +62,5 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:
-        name: windows
+        name: windows_${{ matrix.arch }}
         path: ./build/


### PR DESCRIPTION
Like [This](https://github.com/mnixry/qmc-decoder/actions/runs/165362467)