### PR TITLE
Get rid of warning and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ make
 * for windows
 
 ```bat
-# PowerShell, please install MSVC compiler and Git 
+# PowerShell, please install MSVC compiler and Git with environment variables configured
+# or in x86 or x64 Native Tools Command Prompt for VS 2019 
 git clone https://github.com/Presburger/qmc-decoder.git
 cd qmc-decoder
 git submodule update --init

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -46,9 +46,9 @@ smartFilePtr openFile(const std::string& aPath, openMode aOpenMode) {
 #else
   std::wstring aPath_w;
   aPath_w.resize(aPath.size());
-  int newSize = MultiByteToWideChar(CP_UTF8, 0, aPath.c_str(), aPath.length(),
+  int newSize = MultiByteToWideChar(CP_UTF8, 0, aPath.c_str(), static_cast<int>(aPath.length()),
                                     const_cast<wchar_t*>(aPath_w.c_str()),
-                                    aPath_w.size());
+                                    static_cast<int>(aPath_w.size()));
   aPath_w.resize(newSize);
   std::FILE* fp = NULL;
   _wfopen_s(&fp, aPath_w.c_str(), aOpenMode == openMode::read ? L"rb" : L"wb");


### PR DESCRIPTION
Resolve the warning by MSVC compiler; update instructions for MSVC compiling.
Tested successfully by both GCC and MSVC.