### PR TITLE
Update decoder.cpp:Solve issue #50:display disorder code in windows console when output filename with Chinese/Korean/Japanese words.

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -61,7 +61,14 @@ static const std::regex ogg_regex{"\\.qmcogg$"};
 static const std::regex flac_regex{"\\.qmcflac$"};
 
 void sub_process(std::string dir) {
-  std::cout << "decode: " + dir << std::endl;
+  std::wstring wdir;
+  wdir.resize(("Decode:"+dir).size());
+  int newSize = MultiByteToWideChar(
+      CP_UTF8, 0, ("Decode:"+dir).c_str(), static_cast<int>(("Decode:"+dir).length()),
+      const_cast<wchar_t*>(wdir.c_str()), static_cast<int>(wdir.size()));
+  wdir.resize(newSize);
+  std::wcout.imbue(std::locale("chs"));
+  std::wcout << wdir << std::endl;//使用wstring解决中日韩文字乱码问题(输出语句为wcout)
   std::string outloc(dir);
 
   auto mp3_outloc = regex_replace(outloc, mp3_regex, ".mp3");


### PR DESCRIPTION
使用wstring解决中日韩文字在Windows系统console中显示为乱码的问题