### PR TITLE
Add support for CLI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: linux
-        path: ./build/decoder
+        path: ./build/qmc-decoder
   
   windows:
     name: Build on Windows
@@ -64,7 +64,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: windows_${{ matrix.arch }}
-        path: ./build/decoder.exe
+        path: ./build/qmc-decoder.exe
 
   macos:
     name: Build on MacOS
@@ -90,4 +90,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: macos
-        path: ./build/decoder
+        path: ./build/qmc-decoder

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,5 +16,5 @@ endif()
 
 include_directories(3rdparty/filesystem/include)
 aux_source_directory(src SRC)
-add_executable(decoder ${SRC})
-
+add_executable(qmc-decoder ${SRC})
+install(TARGETS qmc-decoder DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ Run the following command from terminal:
 qmc-decoder /PATH/TO/SONG
 ```
 
+Or:
+
+Put the execuatable file in your qmc file directory, then run the execuatable file.
+
+For mac user, double-click the decoder.command file, before you need to put the `decoder.command` and `decoder` files in the qmc music file directory.
+
+![EjHn9U.gif](https://s2.ax1x.com/2019/05/19/EjHn9U.gif)
+
+For windows user, just click the `decoder-win.exe` when you put the `decoder-win.exe` into your qmc file directory, it will convert all qmc file automatically.
+
+![tW1w7D.gif](https://s1.ax1x.com/2020/06/08/tW1w7D.gif)
 
 * Todo
 

--- a/README.md
+++ b/README.md
@@ -55,15 +55,10 @@ nmake
 
 ## Convert
 
-Put the execuatable file in your qmc file directory, then run the execuatable file.
-
-For mac user, double-click the decoder.command file, before you need to put the `decoder.command` and `decoder` files in the qmc music file directory.
-
-![EjHn9U.gif](https://s2.ax1x.com/2019/05/19/EjHn9U.gif)
-
-For windows user, just click the `decoder-win.exe` when you put the `decoder-win.exe` into your qmc file directory, it will convert all qmc file automatically.
-
-![tW1w7D.gif](https://s1.ax1x.com/2020/06/08/tW1w7D.gif)
+Run the following command from terminal:
+```bash
+qmc-decoder /PATH/TO/SONG
+```
 
 
 * Todo

--- a/decoder.command
+++ b/decoder.command
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd $(dirname $0)
-if [ -f decoder ]; then
-./decoder
+if [ -f qmc-decoder ]; then
+./qmc-decoder
 fi

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -46,9 +46,9 @@ smartFilePtr openFile(const std::string& aPath, openMode aOpenMode) {
 #else
   std::wstring aPath_w;
   aPath_w.resize(aPath.size());
-  int newSize = MultiByteToWideChar(CP_UTF8, 0, aPath.c_str(), static_cast<int>(aPath.length()),
-                                    const_cast<wchar_t*>(aPath_w.c_str()),
-                                    static_cast<int>(aPath_w.size()));
+  int newSize = MultiByteToWideChar(
+      CP_UTF8, 0, aPath.c_str(), static_cast<int>(aPath.length()),
+      const_cast<wchar_t*>(aPath_w.c_str()), static_cast<int>(aPath_w.size()));
   aPath_w.resize(newSize);
   std::FILE* fp = NULL;
   _wfopen_s(&fp, aPath_w.c_str(), aOpenMode == openMode::read ? L"rb" : L"wb");
@@ -124,32 +124,20 @@ static const std::regex qmc_regex{"^.+\\.(qmc3|qmc0|qmcflac|qmcogg)$"};
 }  // namespace
 
 int main(int argc, char** argv) {
-  if (argc > 1) {
-    std::cerr
-        << "put decoder binary file in your qmc file directory, then run it."
-        << std::endl;
-    return -1;
+  // refactor so that the command accept the path to the song as argument.
+  if (argc != 2) {
+    printf("Usage: qmc-decoder /PATH/TO/SONG\n");
+    return 1;
   }
+  auto path = argv[1];
 
-  if ((fs::status(fs::path(".")).permissions() & fs::perms::owner_write) ==
+  if ((fs::status(fs::path(path)).permissions() & fs::perms::owner_read) ==
       fs::perms::none) {
     std::cerr << "please check if you have the write permissions on this dir."
               << std::endl;
     return -1;
   }
-  std::vector<std::string> qmc_paths;
-
-  for (auto& p : fs::recursive_directory_iterator(fs::path("."))) {
-    auto file_path = p.path().string();
-
-    if ((fs::status(p).permissions() & fs::perms::owner_read) !=
-            fs::perms::none &&
-        fs::is_regular_file(p) && regex_match(file_path, qmc_regex)) {
-      qmc_paths.emplace_back(std::move(file_path));
-    }
-  };
-
-  std::for_each(qmc_paths.begin(), qmc_paths.end(), sub_process);
+  sub_process(path);
 
   return 0;
 }


### PR DESCRIPTION
This PR allows the binary to be placed at somewhere in `$PATH` and used as a command line tool:
```bash
qmc-decoder /path/to/song
```
The decoded file will be placed at the same directory as the qmc file.